### PR TITLE
Python interface to beagle-daq using pyspi-dev. Initial commit.

### DIFF
--- a/beagledaq.py
+++ b/beagledaq.py
@@ -1,0 +1,73 @@
+# coding: utf-8
+
+from spidev import SpiDev
+
+class ad7606():
+    try:
+        start_acq_fd = open("/sys/class/gpio/gpio145/value", 'w', 0)
+    except IOError as e:
+        print("Error opening start acquire gpio pin: %s" % e)
+        raise
+
+    def __init__(self, dev):
+        self.dev = SpiDev()
+        try:
+            self.dev.open(3,dev)
+            self.dev.mode = 2
+        except IOError as e:
+            print("Error opening /dev/spidev3.%d: %s" % (dev, e))
+            raise
+
+    def trigger_acquire(self):
+        self.start_acq_fd.write(b'1')
+        self.start_acq_fd.write(b'0')
+
+    def read(self):
+        self.trigger_acquire()
+        buf = self.dev.readbytes(16)
+        samples = [0,0,0,0,0,0,0,0]
+        for i in xrange(8):
+            samples[i] = buf[2*i] << 8 | buf[2*i+1] << 0
+        return samples
+
+class dac8568():
+    def __init__(self, dev):
+        self.dev = SpiDev()
+        try:
+            self.dev.open(4,dev)
+        except IOError as e:
+            print("Error opening /dev/spidev4.%d: %s" % (dev, e))
+            raise
+
+    def build_command(self, control, addr, data):
+        prefix = 0
+        features = 0
+        cmd = [0,0,0,0]
+        cmd[3] = (0xf    & features) << 0 | (0xf & data) << 4
+        cmd[2] = (0x0ff0 & data) >> 4
+        cmd[1] = (0xf000 & data) >> 12    | (0xf & addr) << 4
+        cmd[0] = (0xf    & control) << 0  | (0xf & prefix) << 4
+        return cmd
+       
+    # indexed by label number, mapping to DAC channel number
+    channel_map = (0,2,4,6,7,5,3,1)
+    write_mode = { 'WRITE': 0x0,
+                   'UPDATE': 0x1,
+                   'WRITE_UPDATE_ALL': 0x2,
+                   'WRITE_UPDATE': 0x3 }
+
+    def write(self, addr, data, mode = write_mode['WRITE_UPDATE']):
+        addr = self.channel_map[addr]
+        cmd  = self.build_command(mode, addr, data)
+        self.dev.writebytes(cmd)
+
+class beagle_daq():
+    def __init__(self):
+        self.adc0 = ad7606(0)
+        self.dac0 = dac8568(0)
+
+    def read(self, channel):
+        return self.adc0.read()[channel]
+
+    def write(self, channel, data):
+        self.dac0.write(channel, data)

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+
+from distutils.core import setup
+
+setup(name='beagledaq',
+      version='0.1',
+      description='Library for interfacing with beagle-daq',
+      author='Kieran Ramos',
+      author_email='kramos@physics.umass.edu',
+      url='https://www.github.com/krrk/libbeagledaq',
+      py_modules=['beagledaq'],
+      scripts=['tools/adc-acquire.py','tools/dac-output.py']
+      )

--- a/tools/pyadc-acquire
+++ b/tools/pyadc-acquire
@@ -1,0 +1,12 @@
+#!/usr/bin/env python
+
+# Reads in ADC0 on beagle-daq
+
+import beagledaq
+from time import sleep
+
+bd = beagledaq.beagle_daq()
+
+while True:
+    print bd.adc0.read()
+    sleep(1e-2)

--- a/tools/pybenchmark
+++ b/tools/pybenchmark
@@ -1,0 +1,25 @@
+#!/usr/bin/env python 
+
+import beagledaq
+import timeit
+
+bd = beagledaq.beagle_daq()
+N = 1000000
+
+def read():
+    """ Read adc0 N times """
+    for i in xrange(N):
+        bd.adc0.read()
+
+def write():
+    """ Write 1's to channel 0 100,000 times """
+    for i in xrange(N):
+        bd.write(0, 1)
+
+read_time = timeit.timeit("read()", setup="from __main__ import read",
+                          number=1)
+write_time = timeit.timeit("write()", setup="from __main__ import write",
+                           number=1)
+
+print "ADC Read: %d samples/sec" % int(N/read_time)
+print "DAC Write: %d samples/sec" % int(N/write_time)

--- a/tools/pydac-output
+++ b/tools/pydac-output
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+
+import argparse
+import beagledaq
+from time import sleep
+from math import sin, pi
+
+parser = argparse.ArgumentParser(description='Output a sinusoid on DAC0')
+parser.add_argument('-c', '--channels', type=int, choices=range(8),
+                    action='append', help='Channel(s) to output on')
+parser.add_argument('amplitude', metavar='amp', type=float,
+                    help='Value from 0 to 32767')
+parser.add_argument('frequency', metavar='freq', type=float,
+                    help='Value in Hz')
+
+bd = beagledaq.beagle_daq()
+
+args = parser.parse_args()
+amp = args.amplitude
+freq = args.frequency
+channels = [0] if args.channels == None else args.channels
+t = 0
+while True:
+    data = int(0x7fff + amp*sin(2*pi*(t*1e-3)*freq))
+    for channel in channels:
+        bd.write(channel, data)
+    sleep(1e-3)
+    t += 1


### PR DESCRIPTION
Here is a port of the C++ interface using py-spidev. This was much easier for me to implement than to wrap the C++ interface which had subclass declarations. The subclass declarations made it impossible to wrap using SWIG (at its current version) and it was non-trivial for me in Cython or other approaches. At lease this python interface is much more readable and approachable. It is also nearly as fast! About 70% the speed for read from ADCs and about 85% as fast for writing to the DACs. That is about 3200 ADC samples/sec and 4900 DAC samples/sec.
